### PR TITLE
Adds initial test support with fake() and assertExecuted() methods

### DIFF
--- a/src/LambdaFunction.php
+++ b/src/LambdaFunction.php
@@ -14,6 +14,16 @@ use Illuminate\Support\Str;
 
 abstract class LambdaFunction
 {
+    public static function fake($mockedResponse)
+    {
+        return Sidecar::fake($mockedResponse);
+    }
+
+    public static function assertExecuted($expectedPayload)
+    {
+        return Sidecar::assertExecuted(static::class, $expectedPayload);
+    }
+
     /**
      * Execute the current function and return the response.
      *

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -302,13 +302,13 @@ class Manager
     private function mockExecution($method, $functionPayload)
     {
         $mock = new MockHandler();
-        // Enqueue a mock result to the handler
         $mock->append(new Result(['Payload' => json_encode($this->mockedResponse)]));
 
         /** @var LambdaClient */
         $client = app(LambdaClient::class);
         $command = $client->getCommand($method, $functionPayload);
         $command->getHandlerList()->setHandler($mock);
+
         return $client->execute($command);
     }
 }

--- a/src/Manager.php
+++ b/src/Manager.php
@@ -303,7 +303,7 @@ class Manager
     {
         $mock = new MockHandler();
         // Enqueue a mock result to the handler
-        $mock->append(new Result(['Payload' => $this->mockedResponse]));
+        $mock->append(new Result(['Payload' => json_encode($this->mockedResponse)]));
 
         /** @var LambdaClient */
         $client = app(LambdaClient::class);

--- a/src/Results/SettledResult.php
+++ b/src/Results/SettledResult.php
@@ -54,7 +54,7 @@ class SettledResult implements Responsable, ResultContract
      */
     public function isError()
     {
-        return $this->raw->get('FunctionError') !== '';
+        return $this->raw->hasKey('FunctionError') && !empty($this->raw->get('FunctionError'));
     }
 
     /**


### PR DESCRIPTION
- Adds a `fake()` method which marks the function as "recording"
- Adds a `assertExpected()` method to determine if an execution was called with specific parameters

Usage in user-land where a Lambda is used to invoke puppeteer:

```php
$params = [
    'url' => 'https://owenconti.com'
];
$hash = md5(json_encode($params));

SnapFunction::fake(base64_encode($image)); // This encoded image will be returned as the response from Lambda

// When
$this->get(route('snap.create', array_merge($params, [
    'token' => $token->plainTextToken
])))->assertRedirect("/$hash.png");

// Then

// Testing that we called `SnapFunction::execute` with the correct parameters
SnapFunction::assertExecuted([
    'url' => 'https://owenconti.com',
    'width' => 1280,
    'height' => 720,
    'format' => 'png',
    'quality' => 90,
    'mobile' => false,
    'fullPage' => false,
    'dpi' => 1,
]);
```